### PR TITLE
fix: tombstone binary rep, write commit log on del

### DIFF
--- a/commit.log.test1
+++ b/commit.log.test1
@@ -1,2 +1,3 @@
 three	four	0
 hey	now	0
+one	$T$	0

--- a/lib/august_db/sstable.ex
+++ b/lib/august_db/sstable.ex
@@ -119,6 +119,8 @@ defmodule SSTable do
           case :file.pread(sst, offset, kv_length_bytes()) do
             {:ok, l} ->
               <<key_len::32, value_len::32>> = IO.iodata_to_binary(l)
+              IO.puts("value len:")
+              IO.inspect(value_len)
 
               case value_len do
                 @tombstone ->

--- a/lib/august_db/sstable.ex
+++ b/lib/august_db/sstable.ex
@@ -71,7 +71,7 @@ defmodule SSTable do
 
     {:ok, sst_out_file} = :file.open(table_fname, [:raw, :append])
 
-    idx = kvs |> write_binary_idx(sst_out_file)
+    idx = kvs |> write_sstable_and_index(sst_out_file)
 
     index_path = "#{time}.idx"
     File.write!(index_path, :erlang.term_to_binary(idx))
@@ -141,20 +141,20 @@ defmodule SSTable do
     end
   end
 
-  defp write_binary_idx(pairs, device, acc \\ {0, %{}})
+  defp write_sstable_and_index(pairs, device, acc \\ {0, %{}})
 
   import SSTable.Write
 
-  defp write_binary_idx([{key, value} | rest], device, acc) do
+  defp write_sstable_and_index([{key, value} | rest], device, acc) do
     segment_size = write_kv(key, value, device)
 
     {al, idx} = acc
     next_len = al + segment_size
 
-    write_binary_idx(rest, device, {next_len, Map.put(idx, key, al)})
+    write_sstable_and_index(rest, device, {next_len, Map.put(idx, key, al)})
   end
 
-  defp write_binary_idx([], _device, {_byte_pos, idx}) do
+  defp write_sstable_and_index([], _device, {_byte_pos, idx}) do
     idx
   end
 end

--- a/lib/august_db/sstable.ex
+++ b/lib/august_db/sstable.ex
@@ -119,8 +119,6 @@ defmodule SSTable do
           case :file.pread(sst, offset, kv_length_bytes()) do
             {:ok, l} ->
               <<key_len::32, value_len::32>> = IO.iodata_to_binary(l)
-              IO.puts("value len:")
-              IO.inspect(value_len)
 
               case value_len do
                 @tombstone ->
@@ -146,9 +144,6 @@ defmodule SSTable do
   import SSTable.Write
 
   defp write_sstable_and_index([{key, value} | rest], device, acc) do
-    IO.puts("bout to write")
-    IO.inspect(key)
-    IO.inspect(value)
     segment_size = write_kv(key, value, device)
 
     {al, idx} = acc

--- a/lib/august_db/sstable.ex
+++ b/lib/august_db/sstable.ex
@@ -146,6 +146,9 @@ defmodule SSTable do
   import SSTable.Write
 
   defp write_sstable_and_index([{key, value} | rest], device, acc) do
+    IO.puts("bout to write")
+    IO.inspect(key)
+    IO.inspect(value)
     segment_size = write_kv(key, value, device)
 
     {al, idx} = acc

--- a/lib/august_db/sstable_settings.ex
+++ b/lib/august_db/sstable_settings.ex
@@ -3,7 +3,8 @@ defmodule SSTable.Settings do
     8
   end
 
+  @t 4_294_967_296 - 1
   def tombstone do
-    4_294_967_296
+    @t
   end
 end

--- a/lib/august_db_web/controllers/value_controller.ex
+++ b/lib/august_db_web/controllers/value_controller.ex
@@ -65,6 +65,8 @@ defmodule AugustDbWeb.ValueController do
   ```
   """
   def delete(conn, %{"id" => key}) do
+    CommitLog.append(key, :tombstone)
+
     Memtable.delete(key)
 
     send_resp(conn, 204, "")


### PR DESCRIPTION
Resolves #69 

Fixes the binary representation of tombstones to use `2**32 - 1` instead of `2**32` 😀

Renames a function