### PR TITLE
fix: improve commitlog write speed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,9 +38,6 @@ npm-debug.log
 *.idx
 # AugustDB commit log
 commit.log
-# Backups of the commit log created
-# when Memtable.flush() runs
-*.bak
 # ignore env configuration
 *.env
 # ignore jmeter log

--- a/README.md
+++ b/README.md
@@ -16,13 +16,17 @@ We use phoenix to expose a REST API (PUT, GET, DEL) for creating, reading, updat
 
 ## Webservice operation
 
-To start the Phoenix server:
+To start the Phoenix server in _dev mode_:
 
 - Install dependencies with `mix deps.get`
 - Install Node.js dependencies with `npm install` inside the `assets` directory
 - Start Phoenix endpoint with `mix phx.server`
 
 Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
+
+To run in _prod mode_ with some optimizations, you first need to follow the [Phoenix deployment instructions](https://hexdocs.pm/phoenix/deployment.html) to generate a secret, etc.  Then:
+
+`PORT=4001 MIX_ENV=prod mix phx.server`
 
 ## Making HTTP calls
 

--- a/lib/august_db/application.ex
+++ b/lib/august_db/application.ex
@@ -7,9 +7,11 @@ defmodule AugustDb.Application do
 
   def start(_type, _args) do
     children = [
+      # Start the CommitLog device genserver
+      CommitLog,
       # Start the Memtable agent
       {Memtable, %Memtable{}},
-      # Start Memtable Size tracker
+      # Start Memtable Size genserver
       Memtable.Sizer,
       # Start the SSTable Index agent
       {SSTable.Index, %{}},

--- a/lib/august_db/commitlog.ex
+++ b/lib/august_db/commitlog.ex
@@ -16,7 +16,7 @@ defmodule CommitLog do
     {:ok, device_out}
   end
 
-  def handle_cast({:append, payload}, _from, device_out) do
+  def handle_cast({:append, payload}, device_out) do
     :file.write(device_out, payload)
     {:noreply, device_out}
   end
@@ -32,14 +32,15 @@ defmodule CommitLog do
 
     GenServer.cast(
       CommitLogDevice,
-      key <>
-        TSV.col_separator() <>
-        value <>
-        TSV.col_separator() <>
-        "#{:erlang.monotonic_time()}" <>
-        TSV.col_separator() <>
-        Integer.to_string(crc32, 16) <>
-        TSV.row_separator()
+      {:append,
+       key <>
+         TSV.col_separator() <>
+         value <>
+         TSV.col_separator() <>
+         "#{:erlang.monotonic_time()}" <>
+         TSV.col_separator() <>
+         Integer.to_string(crc32, 16) <>
+         TSV.row_separator()}
     )
   end
 

--- a/lib/august_db/memtable.ex
+++ b/lib/august_db/memtable.ex
@@ -64,10 +64,7 @@ defmodule Memtable do
       }
     end)
 
-    # We should start a new commit log now.
-    # Let's keep a copy of the old one around just in case
-    # we crash (though we don't actually do anything with it)
-    commit_log_backup = CommitLog.backup()
+    # Start a new commit log
     CommitLog.new()
 
     # Write the current memtable to disk in a binary format
@@ -85,10 +82,6 @@ defmodule Memtable do
         flushing: :gb_trees.empty()
       }
     end)
-
-    # Make sure we clean up the backup commit log.  Since the
-    # flush was successful, we don't need it.
-    File.rm!(commit_log_backup)
   end
 
   @doc """

--- a/lib/august_db_web/controllers/value_controller.ex
+++ b/lib/august_db_web/controllers/value_controller.ex
@@ -48,20 +48,9 @@ defmodule AugustDbWeb.ValueController do
   """
   def update(conn, %{"id" => key, "value" => value})
       when is_binary(key) and is_binary(value) do
-    start_commitlog_append = :os.system_time()
     CommitLog.append(key, value)
-    stop_commitlog_append = :os.system_time()
 
-    start_memtable_update = :os.system_time()
     Memtable.update(key, value)
-    stop_memtable_update = :os.system_time()
-
-    commitlog_append_time = stop_commitlog_append - start_commitlog_append
-    memtable_update_time = stop_memtable_update - start_memtable_update
-
-    IO.puts(
-      "Commitlog append time: #{commitlog_append_time}\tMemtable update time: #{memtable_update_time}"
-    )
 
     send_resp(conn, 204, "")
   end

--- a/lib/august_db_web/controllers/value_controller.ex
+++ b/lib/august_db_web/controllers/value_controller.ex
@@ -48,9 +48,20 @@ defmodule AugustDbWeb.ValueController do
   """
   def update(conn, %{"id" => key, "value" => value})
       when is_binary(key) and is_binary(value) do
+    start_commitlog_append = :os.system_time()
     CommitLog.append(key, value)
+    stop_commitlog_append = :os.system_time()
 
+    start_memtable_update = :os.system_time()
     Memtable.update(key, value)
+    stop_memtable_update = :os.system_time()
+
+    commitlog_append_time = stop_commitlog_append - start_commitlog_append
+    memtable_update_time = stop_memtable_update - start_memtable_update
+
+    IO.puts(
+      "Commitlog append time: #{commitlog_append_time}\tMemtable update time: #{memtable_update_time}"
+    )
 
     send_resp(conn, 204, "")
   end


### PR DESCRIPTION
Advances #89 

![Screenshot from 2021-08-08 11-53-19](https://user-images.githubusercontent.com/38859656/128637960-9e52d59f-2671-43a5-99a0-cd2c266c3f53.png)


# tasks

- [x] implement append using genserver cast
- [x] correctly close and reopen the device on memtable flush, etc