### PR TITLE
feat: commit log swapping

### DIFF
--- a/lib/august_db/application.ex
+++ b/lib/august_db/application.ex
@@ -7,7 +7,7 @@ defmodule AugustDb.Application do
 
   def start(_type, _args) do
     children = [
-      # Start the CommitLog device genserver
+      # Start the CommitLog device & filename genserver
       CommitLog,
       # Start the Memtable agent
       {Memtable, %Memtable{}},

--- a/lib/august_db/commitlog/commitlog.ex
+++ b/lib/august_db/commitlog/commitlog.ex
@@ -28,13 +28,14 @@ defmodule CommitLog do
   end
 
   def handle_call(:swap, _from, {last_device, last_path, replay}) do
-    unless replay != nil do
-      :ok = :file.close(last_device)
-      next_path = new_path()
-      {:ok, next_device} = :file.open(next_path, [:append, :raw])
-      {:reply, {:last_path, last_path}, {next_device, next_path, replay}}
-    else
-      {:reply, {:last_path, last_path}, {last_device, last_path, replay}}
+    case replay do
+      nil ->
+        :ok = :file.close(last_device)
+        next_path = new_path()
+        {:ok, next_device} = :file.open(next_path, [:append, :raw])
+        {:reply, {:last_path, last_path}, {next_device, next_path, replay}}
+      _ ->
+        {:reply, {:last_path, last_path}, {last_device, last_path, replay}}
     end
   end
 

--- a/lib/august_db/commitlog/commitlog.ex
+++ b/lib/august_db/commitlog/commitlog.ex
@@ -31,7 +31,7 @@ defmodule CommitLog do
     :ok = :file.close(last_device)
     next_path = new_path()
     {:ok, next_device} = :file.open(next_path, [:append, :raw])
-    {:reply, {:last_path, last_path} , {next_device, next_path, replay}}
+    {:reply, {:last_path, last_path}, {next_device, next_path, replay}}
   end
 
   def handle_cast({:begin_replay, path}, {device, write_path, _}) do

--- a/lib/august_db/commitlog/commitlog.ex
+++ b/lib/august_db/commitlog/commitlog.ex
@@ -2,6 +2,10 @@ NimbleCSV.define(CommitLogParser, separator: TSV.col_separator(), escape: "\"")
 
 defmodule CommitLog do
   use GenServer
+  @moduledoc """
+  Server tracks the device associated with a commit log file,
+  as well as the filename to which we're writing.
+  """
 
   @tsv_header_string "k\tv\tt\tc\n"
   @tombstone_string Tombstone.string()

--- a/lib/august_db/commitlog/commitlog.ex
+++ b/lib/august_db/commitlog/commitlog.ex
@@ -82,9 +82,9 @@ defmodule CommitLog do
   Replay all commit log values into the memtable.
   """
   def replay() do
-    IO.inspect(Path.wildcard("commit-*.log") |>
+    Path.wildcard("commit-*.log") |>
       Enum.filter(&GenServer.call(CommitLogDevice, {:can_delete?, &1})) |>
-      Enum.map(&replay_one(&1))) |>
+      Enum.map(&replay_one(&1)) |>
       Enum.each(fn inactive_path -> case Memtable.flush() do
           :ok ->
             # memtable flush already deleted it

--- a/lib/august_db/commitlog/commitlog.ex
+++ b/lib/august_db/commitlog/commitlog.ex
@@ -34,8 +34,8 @@ defmodule CommitLog do
         next_path = new_path()
         {:ok, next_device} = :file.open(next_path, [:append, :raw])
         {:reply, {:last_path, last_path}, {next_device, next_path, replay}}
-      _ ->
-        {:reply, {:last_path, last_path}, {last_device, last_path, replay}}
+      some_path ->
+        {:reply, {:last_path, last_path}, {last_device, last_path, some_path}}
     end
   end
 
@@ -102,7 +102,6 @@ defmodule CommitLog do
     # currently writing to the file we want to delete.
     if GenServer.call(CommitLogDevice, {:can_delete?, inactive_path})  do
       :ok = :file.delete(inactive_path)
-      IO.puts("Deleted commit log #{inactive_path}")
     else
       IO.puts(:stderr, "Skipping delete of commit log: #{inactive_path}")
     end

--- a/lib/august_db/commitlog/commitlog.ex
+++ b/lib/august_db/commitlog/commitlog.ex
@@ -100,8 +100,8 @@ defmodule CommitLog do
   def delete(inactive_path) do
     # Just to be on the safe side, make sure we aren't
     # currently writing to the file we want to delete.
-    if GenServer.call(CommitLogDevice, {:can_delete?, inactive_path})  do
-      :ok = :file.delete(inactive_path)
+    if GenServer.call(CommitLogDevice, {:can_delete?, inactive_path}) do
+      File.rm!(inactive_path)
     else
       IO.puts(:stderr, "Skipping delete of commit log: #{inactive_path}")
     end

--- a/lib/august_db/commitlog/commitlog.ex
+++ b/lib/august_db/commitlog/commitlog.ex
@@ -111,7 +111,7 @@ defmodule CommitLog do
     # we want to make sure we don't accidentally delete
     # the file after memtable flush
     GenServer.cast(CommitLogDevice, {:begin_replay, log_file})
-    IO.puts("replay commit log #{log_file}")
+    IO.puts("Replaying #{log_file}")
     # we need the header line so that NimbleCSV doesn't fail
     hdr = Stream.cycle([@tsv_header_string]) |> Stream.take(1)
 

--- a/lib/august_db/commitlog/commitlog.ex
+++ b/lib/august_db/commitlog/commitlog.ex
@@ -11,7 +11,6 @@ defmodule CommitLog do
 
   @tsv_header_string "k\tv\tt\tc\n"
   @tombstone_string Tombstone.string()
-  @log_file "commit.log"
 
   def start_link(_) do
     GenServer.start_link(__MODULE__, nil, name: CommitLogDevice)

--- a/lib/august_db/commitlog/path.ex
+++ b/lib/august_db/commitlog/path.ex
@@ -4,7 +4,7 @@ defmodule CommitLog.Path do
   Since these files may persist across restarts of the
   application, we use system time instead of monotonic time.
   """
-  def new() do
+  def new_path() do
     "commit-#{:erlang.system_time()}.log"
   end
 end

--- a/lib/august_db/commitlog/path.ex
+++ b/lib/august_db/commitlog/path.ex
@@ -1,0 +1,10 @@
+defmodule CommitLog.Path do
+  @doc """
+  Generates a new file name for a commit log entry.
+  Since these files may persist across restarts of the
+  application, we use system time instead of monotonic time.
+  """
+  def new() do
+    "commit-#{:erlang.system_time()}.log"
+  end
+end

--- a/lib/august_db/commitlog/path.ex
+++ b/lib/august_db/commitlog/path.ex
@@ -7,4 +7,8 @@ defmodule CommitLog.Path do
   def new_path() do
     "commit-#{:erlang.system_time()}.log"
   end
+
+  def extract_time(path) do
+    String.split(path, ".log") |> hd |> String.split("commit-") |> tl
+  end
 end

--- a/lib/august_db/commitlog/path.ex
+++ b/lib/august_db/commitlog/path.ex
@@ -7,8 +7,4 @@ defmodule CommitLog.Path do
   def new_path() do
     "commit-#{:erlang.system_time()}.log"
   end
-
-  def extract_time(path) do
-    String.split(path, ".log") |> hd |> String.split("commit-") |> tl
-  end
 end

--- a/lib/august_db/memtable/memtable.ex
+++ b/lib/august_db/memtable/memtable.ex
@@ -53,8 +53,8 @@ defmodule Memtable do
 
   def flush() do
     flushing =
-      Agent.get(__MODULE__, fn %__MODULE__{current: current, flushing: pend} ->
-        if :gb_trees.is_empty(pend) && !:gb_trees.is_empty(current) do
+      Agent.get(__MODULE__, fn %__MODULE__{current: current, flushing: flushing} ->
+        if :gb_trees.is_empty(flushing) && !:gb_trees.is_empty(current) do
           {:proceed, current}
         else
           :stop

--- a/lib/august_db/memtable/memtable.ex
+++ b/lib/august_db/memtable/memtable.ex
@@ -77,8 +77,8 @@ defmodule Memtable do
           }
         end)
 
-        # Start a new commit log
-        CommitLog.new()
+        # Start a new commit log.
+        {:old_path, old_path} = CommitLog.swap()
 
         # Write the current memtable to disk in a binary format
         {flushed_sst_path, sparse_index} = SSTable.dump(old_tree)
@@ -95,18 +95,8 @@ defmodule Memtable do
             flushing: :gb_trees.empty()
           }
         end)
-    end
-  end
 
-  @doc """
-  Called by `CommitLog.replay()`
-  """
-  def clear() do
-    Agent.update(__MODULE__, fn %__MODULE__{current: _, flushing: _} ->
-      %__MODULE__{
-        current: :gb_trees.empty(),
-        flushing: :gb_trees.empty()
-      }
-    end)
+        CommitLog.delete(old_path)
+    end
   end
 end

--- a/lib/august_db/memtable/memtable.ex
+++ b/lib/august_db/memtable/memtable.ex
@@ -84,8 +84,9 @@ defmodule Memtable do
           }
         end)
 
-        # Start a new commit log.
-        {:old_path, old_path} = CommitLog.swap()
+        # Start a new commit log.  Remember the name of the old
+        # one so that we can clean it up after the flush is complete.
+        {:last_path, last_commit_log_path} = CommitLog.swap()
 
         # Write the current memtable to disk in a binary format
         {flushed_sst_path, sparse_index} = SSTable.dump(old_tree)
@@ -103,7 +104,7 @@ defmodule Memtable do
           }
         end)
 
-        CommitLog.delete(old_path)
+        CommitLog.delete(last_commit_log_path)
         :ok
     end
   end

--- a/lib/august_db/memtable/memtable.ex
+++ b/lib/august_db/memtable/memtable.ex
@@ -98,7 +98,6 @@ defmodule Memtable do
           }
         end)
 
-        IO.puts("MT FLUSH DEL " <> last_commit_log_path)
         CommitLog.delete(last_commit_log_path)
         :ok
     end

--- a/lib/august_db/startup.ex
+++ b/lib/august_db/startup.ex
@@ -13,7 +13,6 @@ defmodule Startup do
     4. Load all sparse SSTable indices into main memory.
   """
   def init do
-    CommitLog.touch()
     CommitLog.replay()
     Memtable.flush()
     SSTable.Index.load_all()

--- a/lib/august_db/startup.ex
+++ b/lib/august_db/startup.ex
@@ -14,7 +14,6 @@ defmodule Startup do
   """
   def init do
     CommitLog.replay()
-    Memtable.flush()
     SSTable.Index.load_all()
   end
 end

--- a/lib/august_db/startup.ex
+++ b/lib/august_db/startup.ex
@@ -14,6 +14,7 @@ defmodule Startup do
   """
   def init do
     CommitLog.replay()
+    Memtable.flush()
     SSTable.Index.load_all()
   end
 end


### PR DESCRIPTION
Resolves #107. Resolves #104.

## Design goals

- [x] Track the name of the current commit log file in the state of CommitLog server/agent.
- [x] Whenever you flush the memtable, start a new commit log named `"commit-#{:erlang.system_time()}.log"`.
- [x] When you flush the memtable, you can then delete the previous commit log. Don't go back and delete all of them -- we'll handle the replay of old commit logs at app startup only.
- [x] When you start the app, look back to the oldest commit log file. Replay it. Then flush the memtable. Continue this process until you've replayed all of the outdated commit logs. Each memtable flush will delete the commit log that was just replayed.

## Other stuff to do

- [x] clean up `startup.ex`